### PR TITLE
Fix to initialize color scheme when moving buffer

### DIFF
--- a/plugin/iro.vim
+++ b/plugin/iro.vim
@@ -8,7 +8,8 @@ augroup iro
   autocmd Filetype * call Iro_filetype()
 
   autocmd BufWinEnter,BufWinLeave,WinEnter,WinLeave,TabEnter,TabLeave * call iro#redraw()
-  
+  autocmd BufEnter * call s:iro_clean()
+
 augroup END
 
 function! Iro_filetype() abort
@@ -18,4 +19,11 @@ function! Iro_filetype() abort
     call iro#redraw()
     autocmd TextChangedi,TextChanged <buffer> call iro#redraw()
   augroup END
+endfunction
+
+function! s:iro_clean()
+  let filetypes = keys(g:iro#enabled_filetypes)
+  if !count(filetypes, &filetype)
+    execute printf('ruby Iro.clean(%d)', winnr())
+  endif
 endfunction


### PR DESCRIPTION
Fixed a bug that iro.vim drawing was not reset when opening another buffer from filetype with iro.vim color scheme applied.