### PR TITLE
Fix a problem of backslash escaping in a path

### DIFF
--- a/autoload/iro.vim
+++ b/autoload/iro.vim
@@ -1,5 +1,5 @@
 let s:self_path=expand("<sfile>")
-execute 'ruby require "' . s:self_path . '.rb"'
+execute "ruby require '" . s:self_path . ".rb'"
 
 " TODO: merge
 let g:iro#enabled_filetypes = get(g:, 'iro#enabled_filetypes', {

--- a/autoload/iro/ruby.vim
+++ b/autoload/iro/ruby.vim
@@ -1,5 +1,5 @@
 let s:self_path=expand("<sfile>")
-execute 'ruby require "' . s:self_path . '.rb"'
+execute "ruby require '" . s:self_path . ".rb'"
 
 function! iro#ruby#tokens() abort
   execute 'ruby IroVim::Ruby.parse(' . bufnr('%') . ')'

--- a/autoload/iro/yaml.vim
+++ b/autoload/iro/yaml.vim
@@ -1,5 +1,5 @@
 let s:self_path=expand("<sfile>")
-execute 'ruby require "' . s:self_path . '.rb"'
+execute "ruby require '" . s:self_path . ".rb'"
 
 function! iro#yaml#tokens() abort
   execute 'ruby IroVim::YAML.tokens(' . bufnr('%') . ')'


### PR DESCRIPTION
I fixed issue #24. The error is no longer see after this fixing.
However, I'm not sure whether or not this fixing is normal way for vim script.
Furthermore, I have no linux or macos. Hence, I could not check this patch works on linux or macos.
Please merge only when you can see this patch works on linux or macos and you can accept this fixing way.