### PR TITLE
Fix when &fileencoding is empty

### DIFF
--- a/autoload/iro/ruby.vim.rb
+++ b/autoload/iro/ruby.vim.rb
@@ -25,6 +25,8 @@ module IroVim
 
       def vim_to_ruby(vim_enc)
         case vim_enc
+        when ''
+          vim_to_ruby(Vim.evaluate("&encoding"))
         when 'utf-8'
           ::Encoding::UTF_8
         when 'latin1'


### PR DESCRIPTION
&fileencoding option may be an empty and &encoding is used in the case.